### PR TITLE
fix: permit only IST issuer and await it

### DIFF
--- a/agoric/contract/src/proposal/chain-storage-proposal.js
+++ b/agoric/contract/src/proposal/chain-storage-proposal.js
@@ -337,11 +337,13 @@ const executeProposal = async (powers) => {
       startUpgradable,
       chainTimerService,
       agoricNamesAdmin,
-      agoricNames,
       namesByAddressAdmin,
     },
     // @ts-expect-error bakeSaleKit isn't declared in vats/src/core/types.js
     produce: { kreadKit },
+    issuer: {
+      consume: { IST: istIssuerP },
+    },
     instance: {
       // @ts-expect-error bakeSaleKit isn't declared in vats/src/core/types.js
       produce: { [contractInfo.instanceName]: kread },
@@ -360,7 +362,7 @@ const executeProposal = async (powers) => {
     [[platformFeeAddr, 'depositFacet']],
   );
 
-  const istIssuer = await E(agoricNames).lookup('issuer', 'IST');
+  const istIssuer = await istIssuerP;
   const brand = await E(istIssuer).getBrand();
 
   const chainStorageSettled =

--- a/agoric/contract/src/proposal/powers.json
+++ b/agoric/contract/src/proposal/powers.json
@@ -6,11 +6,15 @@
     "zoe": true,
     "startUpgradable": true,
     "agoricNamesAdmin": true,
-    "agoricNames": true,
     "namesByAddressAdmin": true
   },
   "produce": {
     "kreadKit": true
+  },
+  "issuer": {
+    "consume": {
+      "IST": true
+    }
   },
   "instance": {
     "produce": {


### PR DESCRIPTION
In trying to use this code in a test harness, we found that the `E(agoricNames).lookup('issuer', 'IST')` call failed because the IST issuer had not yet been created/registered.

So rather than permitting all of `agoricNames`, pick out just `issuer.consume.IST`, which is a _promise_ for the issuer. Awaiting it provides the necessary synchronization.

This is not really a reduction in authority, since agoricNamesAdmin includes agoricNames. But it makes the permit a bit more clear/precise.

cc @turadg