### PR TITLE
fix: narrow authority to produce issuers/brands

### DIFF
--- a/agoric/contract/src/proposal/chain-storage-proposal.js
+++ b/agoric/contract/src/proposal/chain-storage-proposal.js
@@ -336,13 +336,22 @@ const executeProposal = async (powers) => {
       zoe,
       startUpgradable,
       chainTimerService,
-      agoricNamesAdmin,
       namesByAddressAdmin,
     },
     // @ts-expect-error bakeSaleKit isn't declared in vats/src/core/types.js
     produce: { kreadKit },
+    brand: {
+      produce: {
+        KREAdCHARACTER: produceCharacterBrand,
+        KREAdITEM: produceItemBrand,
+      },
+    },
     issuer: {
       consume: { IST: istIssuerP },
+      produce: {
+        KREAdCHARACTER: produceCharacterIssuer,
+        KREAdITEM: produceItemIssuer,
+      },
     },
     instance: {
       // @ts-expect-error bakeSaleKit isn't declared in vats/src/core/types.js
@@ -459,13 +468,10 @@ const executeProposal = async (powers) => {
   // Share instance widely via E(agoricNames).lookup('instance', <instance name>)
   kread.resolve(instance);
 
-  const kindAdmin = (kind) => E(agoricNamesAdmin).lookupAdmin(kind);
-
-  await E(kindAdmin('issuer')).update('KREAdCHARACTER', characterIssuer);
-  await E(kindAdmin('brand')).update('KREAdCHARACTER', characterBrand);
-
-  await E(kindAdmin('issuer')).update('KREAdITEM', itemIssuer);
-  await E(kindAdmin('brand')).update('KREAdITEM', itemBrand);
+  produceCharacterIssuer.resolve(characterIssuer)
+  produceCharacterBrand.resolve(characterBrand)
+  produceItemIssuer.resolve(itemIssuer)
+  produceItemBrand.resolve(itemBrand)
 
   console.log('ASSETS ADDED TO AGORIC NAMES');
   // Share instance widely via E(agoricNames).lookup('instance', <instance name>)

--- a/agoric/contract/src/proposal/powers.json
+++ b/agoric/contract/src/proposal/powers.json
@@ -5,15 +5,24 @@
     "chainStorage": true,
     "zoe": true,
     "startUpgradable": true,
-    "agoricNamesAdmin": true,
     "namesByAddressAdmin": true
   },
   "produce": {
     "kreadKit": true
   },
+  "brand": {
+    "produce": {
+      "KREAdCHARACTER": true,
+      "KREAdITEM": true
+    }
+  },
   "issuer": {
     "consume": {
       "IST": true
+    },
+    "produce": {
+      "KREAdCHARACTER": true,
+      "KREAdITEM": true
     }
   },
   "instance": {


### PR DESCRIPTION
Rather than `agoricNamesAdmin`, which is authority to update/replace things like the IST brand and issuer, permit producing exactly the relevant brands and issuers.

fixes https://github.com/Kryha/KREAd/issues/2

_currently untested; I hope it's still helpful_