### PR TITLE
feat: register publishItemCollection as a governed API

### DIFF
--- a/agoric/contract/src/index.js
+++ b/agoric/contract/src/index.js
@@ -164,7 +164,9 @@ export const start = async (zcf, privateArgs, baggage) => {
     ),
   );
 
-  const { governorFacet } = makeDurableGovernorFacet(baggage, kreadKit.creator);
+  const { governorFacet } = makeDurableGovernorFacet(baggage, kreadKit.creator, {
+    publishItemCollection: () => kreadKit.market.publishItemCollection(),
+  });
   return harden({
     creatorFacet: governorFacet,
     // no governed parameters, so no need to augment.

--- a/agoric/contract/src/kreadCommitteeCharter.js
+++ b/agoric/contract/src/kreadCommitteeCharter.js
@@ -53,10 +53,42 @@ export const start = async (zcf, privateArgs, baggage) => {
     return zcf.makeInvitation(voteOnOfferFilterHandler, 'vote on offer filter');
   };
 
+  /**
+   * @param {Instance} instance
+   * @param {string} methodName
+   * @param {string[]} methodArgs
+   * @param {import('@agoric/time').TimestampValue} deadline
+   */
+  const makeApiInvocationInvitation = (
+    instance,
+    methodName,
+    methodArgs,
+    deadline,
+  ) => {
+    const handler = (seat) => {
+      seat.exit();
+
+      const governor = instanceToGovernor.get(instance);
+      return E(governor).voteOnApiInvocation(
+        methodName,
+        methodArgs,
+        counter,
+        deadline,
+      );
+    };
+    return zcf.makeInvitation(handler, 'vote on API invocation');
+  };
+
   const MakerI = M.interface('Charter InvitationMakers', {
     VoteOnPauseOffers: M.call(
       InstanceHandleShape,
       M.arrayOf(M.string()),
+      TimestampShape,
+    ).returns(M.promise()),
+    VoteOnApiCall: M.call(
+      InstanceHandleShape,
+      M.string(),
+      M.arrayOf(M.any()),
       TimestampShape,
     ).returns(M.promise()),
   });
@@ -69,6 +101,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     MakerI,
     {
       VoteOnPauseOffers: makeOfferFilterInvitation,
+      VoteOnApiCall: makeApiInvocationInvitation,
     },
   );
 

--- a/agoric/contract/src/kreadKit.js
+++ b/agoric/contract/src/kreadKit.js
@@ -1814,7 +1814,11 @@ export const prepareKreadKit = async (
     },
   );
   const facets = makeKreadKitInternal();
-  return harden({ public: facets.public, creator: facets.creator });
+  return harden({
+    public: facets.public,
+    creator: facets.creator,
+    market: facets.market,
+  });
 };
 
 harden(prepareKreadKit);


### PR DESCRIPTION
Takes advantage of the recently added call on `makeDurableGovernorFacet` to register the governed API.

The facets are exposed from `kreadKit.js` to `index.js`, which only exposes `creator` and `public` as facets.