### PR TITLE
Fix marketplaceAverageLevel metric

### DIFF
--- a/agoric/contract/src/market-metrics.js
+++ b/agoric/contract/src/market-metrics.js
@@ -62,7 +62,7 @@ export const updateCollectionMetrics = (collection, state, updateMetrics) => {
     metrics.marketplaceAverageLevel = updateAverage(
       updateMetrics.marketplaceAverageLevel.type,
       metrics.marketplaceAverageLevel,
-      state.market.characterEntries.getSize(),
+      state.market[`${collection}Entries`].getSize(),
       updateMetrics.marketplaceAverageLevel.value,
     );
   }


### PR DESCRIPTION
Fixed marketplaceAverageLevel metric. For items, this metric was being calculated incorrectly. This lead to specific cases where the metric might become a negative value after updating. This would violate the typeguard of the metric which expects it to be greater or equal than 0 and an error would be thrown. This means the buy item flow would not complete hence why the item would still remain in the market state.

Fixes 2 bugs:
1. #61 
2. #53 
