### PR TITLE
Bug: Low: Keplr Connect button makes Keprl logo disappear on hover

### DIFF
--- a/frontend/src/components/atoms/button.ts
+++ b/frontend/src/components/atoms/button.ts
@@ -11,6 +11,8 @@ interface ButtonProps {
   disabled?: boolean;
 }
 
+export const KeplerIconWrapper = styled.div``;
+
 export const PrimaryButton = styled.button<ButtonProps>`
   max-height: 35px;
   transition: all 0.4s ease 0s;
@@ -36,6 +38,9 @@ export const PrimaryButton = styled.button<ButtonProps>`
     box-sizing: border-box;
     ${ButtonText} {
       color: ${(props): string => props.fontColor || color.black};
+    }
+    ${KeplerIconWrapper} svg {
+      filter: invert(100%);
     }
   }
   &:active {

--- a/frontend/src/pages/connect-wallet/connect-wallet.tsx
+++ b/frontend/src/pages/connect-wallet/connect-wallet.tsx
@@ -8,6 +8,7 @@ import {
   FadeInOut,
   Footer,
   Kado,
+  KeplerIconWrapper,
   LoadingPage,
   MenuText,
   NotificationDetail,
@@ -69,7 +70,9 @@ export const ConnectWallet: FC = () => {
         <ButtonContainer isVisible={isConnectButtonVisible}>
           <ButtonRow>
             <PrimaryButton onClick={() => provisionWallet()}>
-              <KeplerIcon />
+              <KeplerIconWrapper>
+                <KeplerIcon />
+              </KeplerIconWrapper>
               <ButtonText customColor={color.white}>{text.general.activateWallet}</ButtonText>
               {isLoading ? <LoadingPage /> : <ArrowUp />}
             </PrimaryButton>

--- a/frontend/src/pages/onboarding/onboarding.tsx
+++ b/frontend/src/pages/onboarding/onboarding.tsx
@@ -9,6 +9,7 @@ import {
   FadeInOut,
   Footer,
   Kado,
+  KeplerIconWrapper,
   MenuText,
   OnboardingCharacter,
   Overlay,
@@ -74,7 +75,9 @@ export const Onboarding: FC = () => {
         <ButtonContainer isVisible={isConnectButtonVisible}>
           <ButtonRow>
             <PrimaryButton onClick={() => connectWallet()}>
-              <KeplerIcon />
+              <KeplerIconWrapper>
+                <KeplerIcon />
+              </KeplerIconWrapper>
               <ButtonText customColor={color.white}>{text.general.connectWallet}</ButtonText>
               <ArrowUp />
             </PrimaryButton>


### PR DESCRIPTION
Fixes #78 by inverting the logo on hover.

![after-logo-hover](https://github.com/Kryha/KREAd/assets/510222/1574597b-5f0e-447b-92d7-98c203e3a11b)
