### PR TITLE
Frontend Offer Callback Pattern

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,5 +102,5 @@
     "vite-plugin-svgr": "^2.2.1",
     "vite-tsconfig-paths": "^3.5.0"
   },
-  "packageManager": "yarn@1.22.19"
+  "packageManager": "yarn@4.0.0"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,5 +102,5 @@
     "vite-plugin-svgr": "^2.2.1",
     "vite-tsconfig-paths": "^3.5.0"
   },
-  "packageManager": "yarn@4.0.0"
+  "packageManager": "yarn@1.22.19"
 }

--- a/frontend/src/components/asset-card/item-card-inventory.tsx
+++ b/frontend/src/components/asset-card/item-card-inventory.tsx
@@ -48,7 +48,7 @@ export const ItemCardInventory: FC<Props> = ({ item, selectItem }) => {
   const unequipAsset = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setShowToast(true);
-    unequipItem.mutate({ item, callback: handleOfferResultBuilder() });
+    unequipItem.mutate({ item, callback: handleOfferResultBuilder(undefined, undefined, () => console.log("YURR")) });
   };
 
   const sellAsset = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/frontend/src/components/asset-card/item-card-inventory.tsx
+++ b/frontend/src/components/asset-card/item-card-inventory.tsx
@@ -23,6 +23,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { ErrorView } from "../error-view";
 import { routes } from "../../navigation";
 import { useCharacterBuilder } from "../../context/character-builder-context";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 interface Props {
   item: Item;
@@ -41,13 +42,13 @@ export const ItemCardInventory: FC<Props> = ({ item, selectItem }) => {
   const equipAsset = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setShowToast(true);
-    equipItem.mutate({ item });
+    equipItem.mutate({ item, callback: handleOfferResultBuilder() });
   };
 
   const unequipAsset = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setShowToast(true);
-    unequipItem.mutate({ item });
+    unequipItem.mutate({ item, callback: handleOfferResultBuilder() });
   };
 
   const sellAsset = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/frontend/src/components/asset-details/item-details-inventory.tsx
+++ b/frontend/src/components/asset-details/item-details-inventory.tsx
@@ -11,6 +11,7 @@ import { ErrorView } from "../error-view";
 import { Item } from "../../interfaces";
 import { NotificationWrapper } from "../notification-detail/styles";
 import { NotificationDetail } from "../notification-detail";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 interface ItemDetailsInventoryProps {
   item: Item;
@@ -32,12 +33,12 @@ export const ItemDetailsInventory: FC<ItemDetailsInventoryProps> = ({ item, sele
   if (equipItem.isError || unequipItem.isError) return <ErrorView />;
   const equipAsset = () => {
     setShowToast(!showToast);
-    equipItem.mutate({ item });
+    equipItem.mutate({ item, callback: handleOfferResultBuilder() });
   };
 
   const unequipAsset = () => {
     setShowToast(!showToast);
-    unequipItem.mutate({ item });
+    unequipItem.mutate({ item, callback: handleOfferResultBuilder() });
   };
 
   const sellAsset = () => {

--- a/frontend/src/components/menu-card/menu-card.tsx
+++ b/frontend/src/components/menu-card/menu-card.tsx
@@ -45,10 +45,10 @@ export const MenuCard: FC<MenuCardProps> = ({ title, category, equippedItemProp,
   const [showToast, setShowToast] = useState(false);
   const [equippedItem, setEquippedItem] = useState(equippedItemProp);
 
-  const equipItem = useEquipItem(setEquippedItem);
+  const equipItem = useEquipItem();
   const unequipItem = useUnequipItem();
 
-  const successCallback = () => setEquippedItem(undefined)
+  const unequipSuccessCallback = () => setEquippedItem(undefined);
 
   const allItems = useMemo(() => {
     if (equippedItem) return [equippedItem, ...unequippedItems];
@@ -61,14 +61,14 @@ export const MenuCard: FC<MenuCardProps> = ({ title, category, equippedItemProp,
     event.stopPropagation();
     setShowToast(!showToast);
     if (!selectedItem) return;
-    equipItem.mutate({ item: selectedItem, callback: handleOfferResultBuilder() });
+    equipItem.mutate({ item: selectedItem, callback: handleOfferResultBuilder(undefined, undefined, setEquippedItem) });
   };
 
   const unequip = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setShowToast(!showToast);
     if (!equippedItem) return;
-    unequipItem.mutate({ item: equippedItem, callback: handleOfferResultBuilder(undefined, undefined, successCallback) });
+    unequipItem.mutate({ item: equippedItem, callback: handleOfferResultBuilder(undefined, undefined, unequipSuccessCallback) });
   };
 
   const primaryActions = () => {

--- a/frontend/src/components/menu-card/menu-card.tsx
+++ b/frontend/src/components/menu-card/menu-card.tsx
@@ -27,6 +27,7 @@ import { useEquipItem, useUnequipItem } from "../../service";
 import { FadeInOut } from "../fade-in-out";
 import { NotificationDetail } from "../notification-detail";
 import { NotificationWrapper } from "../notification-detail/styles";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 interface MenuCardProps {
   title: string;
@@ -45,7 +46,9 @@ export const MenuCard: FC<MenuCardProps> = ({ title, category, equippedItemProp,
   const [equippedItem, setEquippedItem] = useState(equippedItemProp);
 
   const equipItem = useEquipItem(setEquippedItem);
-  const unequipItem = useUnequipItem(() => setEquippedItem(undefined));
+  const unequipItem = useUnequipItem();
+
+  const successCallback = () => setEquippedItem(undefined)
 
   const allItems = useMemo(() => {
     if (equippedItem) return [equippedItem, ...unequippedItems];
@@ -58,14 +61,14 @@ export const MenuCard: FC<MenuCardProps> = ({ title, category, equippedItemProp,
     event.stopPropagation();
     setShowToast(!showToast);
     if (!selectedItem) return;
-    equipItem.mutate({ item: selectedItem });
+    equipItem.mutate({ item: selectedItem, callback: handleOfferResultBuilder() });
   };
 
   const unequip = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setShowToast(!showToast);
     if (!equippedItem) return;
-    unequipItem.mutate({ item: equippedItem });
+    unequipItem.mutate({ item: equippedItem, callback: handleOfferResultBuilder(undefined, undefined, successCallback) });
   };
 
   const primaryActions = () => {

--- a/frontend/src/containers/canvas/items-mode/items-mode.tsx
+++ b/frontend/src/containers/canvas/items-mode/items-mode.tsx
@@ -19,6 +19,7 @@ import { ModeScroller } from "../mode-scroller/mode-scroller";
 import { color } from "../../../design";
 import { useGetItemSelectionForCharacter } from "../item-cards/hooks";
 import { ItemNotifications } from "./item-notifications";
+import { handleOfferResultBuilder } from "../../../util/contract-callbacks";
 
 export const ItemsMode: FC = () => {
   const navigate = useNavigate();
@@ -58,12 +59,13 @@ export const ItemsMode: FC = () => {
       equipItem.mutate({
         item: selected,
         currentlyEquipped: equipped.inCategory,
+        callback: handleOfferResultBuilder(),
       });
     }
     setOnAssetChange(false);
     setShowToast(!showToast);
     if (!equipped.inCategory && selected) {
-      equipItem.mutate({ item: selected });
+      equipItem.mutate({ item: selected, callback: handleOfferResultBuilder() });
     }
   };
 
@@ -72,7 +74,7 @@ export const ItemsMode: FC = () => {
     setOnAssetChange(false);
     setShowToast(!showToast);
     if (equipped.inCategory) {
-      unequipItem.mutate({ item: equipped.inCategory });
+      unequipItem.mutate({ item: equipped.inCategory, callback: handleOfferResultBuilder() });
     }
   };
 

--- a/frontend/src/containers/detail-section/detail-section-items/detail-section-items.tsx
+++ b/frontend/src/containers/detail-section/detail-section-items/detail-section-items.tsx
@@ -18,6 +18,7 @@ import {
   LevelLabel,
   ListContainer,
 } from "./styles";
+import { handleOfferResultBuilder } from "../../../util/contract-callbacks";
 
 interface ListItemProps {
   item: Item | undefined;
@@ -32,7 +33,7 @@ const ListItem: FC<ListItemProps> = ({ item, showToast }) => {
 
   const unequip = () => {
     showToast();
-    unequipItem.mutate({ item });
+    unequipItem.mutate({ item, callback: handleOfferResultBuilder() });
   };
 
   return (

--- a/frontend/src/interfaces/agoric.interfaces.ts
+++ b/frontend/src/interfaces/agoric.interfaces.ts
@@ -136,8 +136,15 @@ export interface OfferProposal {
   want: any;
 }
 
-export interface HandleOfferResultFunction {
+export interface HandleOfferResult {
   ({ status, data }: { status: string; data: object }): any;
+}
+
+export interface HandleOfferResultBuilder {
+  errorCallbackFunction?: (data: string, ...rest: any[]) => any;
+  refundCallbackFunction?: Function;
+  successCallbackFunction?: Function;
+  getHandleOfferResult: () => HandleOfferResult;
 }
 
 export interface HandleOfferResultBuilderFunction {
@@ -145,5 +152,5 @@ export interface HandleOfferResultBuilderFunction {
     errorCallback?: (data: string, ...rest: any[]) => any,
     refundCallback?: Function,
     successCallback?: Function,
-  ): HandleOfferResultFunction;
+  ): HandleOfferResultBuilder;
 }

--- a/frontend/src/interfaces/agoric.interfaces.ts
+++ b/frontend/src/interfaces/agoric.interfaces.ts
@@ -136,8 +136,16 @@ export interface OfferProposal {
   want: any;
 }
 
+export type OfferStatusType = "error" | "refunded" | "accepted" | "seated";
+export const OFFER_STATUS = {
+  error: "error",
+  refunded: "refunded",
+  accepted: "accepted",
+  seated: "seated",
+};
+
 export interface HandleOfferResult {
-  ({ status, data }: { status: string; data: object }): any;
+  ({ status, data }: { status: OfferStatusType; data: object }): any;
 }
 
 export interface HandleOfferResultBuilder {

--- a/frontend/src/interfaces/agoric.interfaces.ts
+++ b/frontend/src/interfaces/agoric.interfaces.ts
@@ -136,10 +136,14 @@ export interface OfferProposal {
   want: any;
 }
 
+export interface HandleOfferResultFunction {
+  ({ status, data }: { status: string; data: object }): any;
+}
+
 export interface HandleOfferResultBuilderFunction {
   (
-    errorCallback: (data: string, ...rest: any[]) => any,
-    refundCallback: Function,
-    successCallback: Function,
-  ): ({ status, data }: { status: string; data: object }) => any;
+    errorCallback?: (data: string, ...rest: any[]) => any,
+    refundCallback?: Function,
+    successCallback?: Function,
+  ): HandleOfferResultFunction;
 }

--- a/frontend/src/interfaces/agoric.interfaces.ts
+++ b/frontend/src/interfaces/agoric.interfaces.ts
@@ -136,12 +136,11 @@ export interface OfferProposal {
   want: any;
 }
 
-export type OfferStatusType = "error" | "refunded" | "accepted" | "seated";
+export type OfferStatusType = "error" | "refunded" | "accepted";
 export const OFFER_STATUS = {
   error: "error",
   refunded: "refunded",
   accepted: "accepted",
-  seated: "seated",
 };
 
 export interface HandleOfferResult {

--- a/frontend/src/interfaces/agoric.interfaces.ts
+++ b/frontend/src/interfaces/agoric.interfaces.ts
@@ -1,7 +1,7 @@
 interface Contracts {
   kread: {
     instance: any;
-  }
+  };
 }
 
 interface Status {
@@ -64,7 +64,6 @@ interface UpdateStatus {
   type: "UPDATE_STATUS";
   payload: { [key: string]: boolean };
 }
-
 
 interface SetOffers {
   type: "SET_OFFERS";
@@ -135,4 +134,12 @@ export type AgoricStateActions =
 export interface OfferProposal {
   give: any;
   want: any;
+}
+
+export interface HandleOfferResultBuilderFunction {
+  (
+    errorCallback: (data: string, ...rest: any[]) => any,
+    refundCallback: Function,
+    successCallback: Function,
+  ): ({ status, data }: { status: string; data: object }) => any;
 }

--- a/frontend/src/interfaces/character.interfaces.ts
+++ b/frontend/src/interfaces/character.interfaces.ts
@@ -1,5 +1,6 @@
 import { CATEGORY, ORIGIN, TITLE } from "../constants";
 import { ActivityEvent } from "./activity.interfaces";
+import { HandleOfferResultBuilderFunction } from "./agoric.interfaces";
 import { Item } from "./item.interfaces";
 
 export type Origin = (typeof ORIGIN)[keyof typeof ORIGIN];
@@ -99,5 +100,5 @@ export interface CharacterInMarketBackend {
 
 export interface CharacterCreation {
   name: string;
-  setError?: (error: string) => void
+  callback: ReturnType<HandleOfferResultBuilderFunction>;
 }

--- a/frontend/src/interfaces/character.interfaces.ts
+++ b/frontend/src/interfaces/character.interfaces.ts
@@ -1,6 +1,6 @@
 import { CATEGORY, ORIGIN, TITLE } from "../constants";
 import { ActivityEvent } from "./activity.interfaces";
-import { HandleOfferResultBuilderFunction } from "./agoric.interfaces";
+import { HandleOfferResultBuilderFunction, HandleOfferResultFunction } from "./agoric.interfaces";
 import { Item } from "./item.interfaces";
 
 export type Origin = (typeof ORIGIN)[keyof typeof ORIGIN];
@@ -100,5 +100,5 @@ export interface CharacterInMarketBackend {
 
 export interface CharacterCreation {
   name: string;
-  callback: ReturnType<HandleOfferResultBuilderFunction>;
+  callback: HandleOfferResultFunction;
 }

--- a/frontend/src/interfaces/character.interfaces.ts
+++ b/frontend/src/interfaces/character.interfaces.ts
@@ -1,6 +1,5 @@
 import { CATEGORY, ORIGIN, TITLE } from "../constants";
 import { ActivityEvent } from "./activity.interfaces";
-import { HandleOfferResultBuilderFunction, HandleOfferResultFunction } from "./agoric.interfaces";
 import { Item } from "./item.interfaces";
 
 export type Origin = (typeof ORIGIN)[keyof typeof ORIGIN];
@@ -100,5 +99,4 @@ export interface CharacterInMarketBackend {
 
 export interface CharacterCreation {
   name: string;
-  callback: HandleOfferResultFunction;
 }

--- a/frontend/src/pages/buy/character-buy.tsx
+++ b/frontend/src/pages/buy/character-buy.tsx
@@ -6,6 +6,7 @@ import { ErrorView, LoadingPage } from "../../components";
 import { CharacterInMarket } from "../../interfaces";
 import { useBuyCharacter, useCharacterFromMarket, useMyCharacter } from "../../service";
 import { Buy } from "./buy";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 export const CharacterBuy = () => {
   const { id } = useParams<"id">();
@@ -32,7 +33,7 @@ export const CharacterBuy = () => {
   const handleSubmit = async () => {
     if (!id) return;
     setIsAwaitingApproval(true);
-    await buyCharacter.callback();
+    await buyCharacter.callback(handleOfferResultBuilder());
   };
 
   if (isLoadingCharacter) return <LoadingPage spinner={false} />;

--- a/frontend/src/pages/buy/item-buy.tsx
+++ b/frontend/src/pages/buy/item-buy.tsx
@@ -6,6 +6,7 @@ import { useBuyItem } from "../../service";
 import { Buy } from "./buy";
 import { useItemMarketState } from "../../context/item-shop-context";
 import { ErrorView } from "../../components";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 export const ItemBuy = () => {
   const { id } = useParams<"id">();
@@ -32,7 +33,7 @@ export const ItemBuy = () => {
     await buyItem.callback(() => {
       setIsOfferAccepted(true);
       setIsAwaitingApproval(false);
-    });
+    }, handleOfferResultBuilder());
   };
 
   if (!data) return <ErrorView />;

--- a/frontend/src/pages/create-character/create-character.tsx
+++ b/frontend/src/pages/create-character/create-character.tsx
@@ -15,6 +15,7 @@ import { breakpoints } from "../../design";
 import { useUserState } from "../../context/user";
 import { useWalletState } from "../../context/wallet";
 import { NotificationWrapper } from "../../components/notification-detail/styles";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 export const CreateCharacter: FC = () => {
   const createCharacter = useCreateCharacter();
@@ -33,8 +34,8 @@ export const CreateCharacter: FC = () => {
   const mobile = useIsMobile(breakpoints.desktop);
   const { ist } = useWalletState();
 
-  const notEnoughIST = useMemo(()=>{
-    if(ist < MINTING_COST || !ist) {
+  const notEnoughIST = useMemo(() => {
+    if (ist < MINTING_COST || !ist) {
       return true;
     }
     return false;
@@ -53,14 +54,21 @@ export const CreateCharacter: FC = () => {
     setCurrentStep(step);
   };
 
-  const handleError = (error: string) => {
+  const errorCallback = (error: string) => {
     setError(error);
     setShowToast(true);
-  }
+  };
+
+  const successCallback = () => {
+    console.info("MintCharacter call settled");
+  };
 
   const sendOfferHandler = async (): Promise<void> => {
     setIsLoading(true);
-    await createCharacter.mutateAsync({ name: characterData.name, setError: handleError });
+    await createCharacter.mutateAsync({
+      name: characterData.name,
+      callback: handleOfferResultBuilder(errorCallback, errorCallback, successCallback),
+    });
   };
 
   const setData = async (data: CharacterCreation): Promise<void> => {

--- a/frontend/src/pages/landing/landing.tsx
+++ b/frontend/src/pages/landing/landing.tsx
@@ -27,7 +27,7 @@ import { CharacterCanvas } from "../../containers/canvas/character-canvas/charac
 import { useViewport } from "../../hooks";
 import { useCharacterBuilder } from "../../context/character-builder-context";
 import { CategoryMode } from "../../containers/canvas/category-mode/category-mode";
-import { CATEGORY_MODE, CHARACTER_SELECT_MODE, ITEM_MODE, MAIN_MODE } from "../../constants";
+import { CATEGORY_MODE, CHARACTER_SELECT_MODE, INVENTORY_CALL_FETCH_DELAY, ITEM_MODE, MAIN_MODE } from "../../constants";
 import { ItemsMode } from "../../containers/canvas/items-mode/items-mode";
 import { CharactersMode } from "../../containers/canvas/characters-mode/characters-mode";
 import { MainMode } from "../../containers/canvas/main-mode/main-mode";
@@ -35,6 +35,8 @@ import { calculateCharacterLevels } from "../../util";
 import { AssetTag } from "../../components/asset-card/styles";
 import { color } from "../../design";
 import { ButtonInfoWrap } from "../../components/button-info/styles";
+import { useUserStateDispatch } from "../../context/user";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 export const Landing: FC = () => {
   const navigate = useNavigate();
@@ -59,19 +61,19 @@ export const Landing: FC = () => {
 
   const equipItem = useEquipItem();
   const unequipItem = useUnequipItem();
-
+  
   if (equipItem.isError || unequipItem.isError) return <ErrorView />;
   const equipAsset = () => {
     setShowToast(!showToast);
     if (item) {
-      equipItem.mutate({ item });
+      equipItem.mutate({ item, callback: handleOfferResultBuilder() });
     }
   };
 
   const unequipAsset = () => {
     setShowToast(!showToast);
     if (item) {
-      unequipItem.mutate({ item });
+      unequipItem.mutate({ item, callback: handleOfferResultBuilder(undefined, undefined, undefined) });
     }
   };
 

--- a/frontend/src/pages/sell/character-sell.tsx
+++ b/frontend/src/pages/sell/character-sell.tsx
@@ -5,6 +5,7 @@ import { ErrorView } from "../../components";
 import { useMyCharacter, useSellCharacter } from "../../service";
 import { Sell } from "./sell";
 import { SellData } from "./types";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 export const CharacterSell = () => {
   const { id } = useParams<"id">();
@@ -19,7 +20,7 @@ export const CharacterSell = () => {
 
   const sendOfferHandler = async (data: SellData) => {
     if (data.price < 1) return; // We don't want to sell for free in case someone managed to fool the frontend
-    await sellCharacter.callback(data.price, () => setIsPlacedInShop(true));
+    await sellCharacter.callback(data.price, handleOfferResultBuilder(), () => setIsPlacedInShop(true));
   };
 
   const characterName = useMemo(() => character?.nft.name, [character]);

--- a/frontend/src/pages/sell/item-sell.tsx
+++ b/frontend/src/pages/sell/item-sell.tsx
@@ -6,6 +6,7 @@ import { useSellItem } from "../../service";
 import { Sell } from "./sell";
 import { SellData } from "./types";
 import { Category, isItemCategory } from "../../interfaces";
+import { handleOfferResultBuilder } from "../../util/contract-callbacks";
 
 export const ItemSell = () => {
   const { name, category } = useParams<"category" | "name">();
@@ -15,7 +16,7 @@ export const ItemSell = () => {
 
   const sendOfferHandler = async (data: SellData) => {
     if (data.price < 1) return; // We don't want to sell for free in case someone managed to fool the frontend
-    await sellItem.callback(data.price, () => setIsPlacedInShop(true) );
+    await sellItem.callback(data.price, () => setIsPlacedInShop(true), handleOfferResultBuilder());
   };
 
   if (!data || !isItemCategory(category)) return <ErrorView />;

--- a/frontend/src/service/character.ts
+++ b/frontend/src/service/character.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "react-query";
 
-import { CharacterCreation, CharacterInMarket, ExtendedCharacter, MarketMetrics } from "../interfaces";
+import { CharacterInMarket, ExtendedCharacter, HandleOfferResultBuilder, MarketMetrics } from "../interfaces";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { extendCharacters } from "./transform-character";
 import { useAgoricContext, useAgoricState } from "../context/agoric";
@@ -62,15 +62,11 @@ export const useSelectedCharacter = (): [ExtendedCharacter | undefined, boolean]
 };
 
 export const useMyCharactersForSale = () => {
-  const [
-    {
-      chainStorageWatcher,
-    },
-  ] = useAgoricContext();
+  const [{ chainStorageWatcher }] = useAgoricContext();
   const wallet = useWalletState();
 
   // stringified ExtendedCharacterBackend[], for some reason the state goes wild if I make it an array
-  const [offerCharacters, setOfferCharacters] = useState<string>("[]"); 
+  const [offerCharacters, setOfferCharacters] = useState<string>("[]");
 
   // adding items to characters from offers
   useEffect(() => {
@@ -157,7 +153,7 @@ export const useCreateCharacter = () => {
   const service = useAgoricState();
   const instance = service.contracts.kread.instance;
   const istBrand = service.tokenInfo.ist.brand;
-  return useMutation(async (body: CharacterCreation): Promise<void> => {
+  return useMutation(async (body: { name: string; callback: HandleOfferResultBuilder }): Promise<void> => {
     if (!body.name) throw new Error("Name not specified");
     await mintCharacter({
       name: body.name,
@@ -166,7 +162,7 @@ export const useCreateCharacter = () => {
         istBrand: istBrand,
         makeOffer: service.walletConnection.makeOffer,
       },
-      callback: body.callback,
+      callback: body.callback.getHandleOfferResult(),
     });
   });
 };

--- a/frontend/src/service/character.ts
+++ b/frontend/src/service/character.ts
@@ -184,14 +184,16 @@ export const useSellCharacter = (characterId: number) => {
       const characterToSell = { ...found.nft, id: Number(found.nft.id) };
       const uISTPrice = ISTTouIST(price);
 
+      const originalSuccessCallbackFunction = callback.successCallbackFunction;
       callback.successCallbackFunction = () => {
-        if (callback.successCallbackFunction) callback.successCallbackFunction();
+        if (originalSuccessCallbackFunction) originalSuccessCallbackFunction();
         console.info("SellCharacter call settled");
         setIsLoading(false);
         userDispatch({ type: "SET_SELECTED", payload: "" });
       };
+      const originalRefundCallbackFunction = callback.refundCallbackFunction;
       callback.refundCallbackFunction = () => {
-        if (callback.refundCallbackFunction) callback.refundCallbackFunction();
+        if (originalRefundCallbackFunction) originalRefundCallbackFunction();
         console.info("SellCharacter call settled");
         setIsLoading(false);
         userDispatch({ type: "SET_SELECTED", payload: "" });
@@ -238,14 +240,15 @@ export const useBuyCharacter = (characterId: string) => {
         ...found,
         character: found.character,
       };
-
+      const originalSuccessCallbackFunction = callback.successCallbackFunction;
       callback.successCallbackFunction = () => {
-        if (callback.successCallbackFunction) callback.successCallbackFunction();
+        if (originalSuccessCallbackFunction) originalSuccessCallbackFunction();
         console.info("BuyCharacter call settled");
         setIsLoading(false);
       };
+      const originalRefundCallbackFunction = callback.refundCallbackFunction;
       callback.refundCallbackFunction = () => {
-        if (callback.refundCallbackFunction) callback.refundCallbackFunction();
+        if (originalRefundCallbackFunction) originalRefundCallbackFunction();
         console.info("BuyCharacter call settled");
         setIsLoading(false);
       };

--- a/frontend/src/service/character.ts
+++ b/frontend/src/service/character.ts
@@ -166,10 +166,7 @@ export const useCreateCharacter = () => {
         istBrand: istBrand,
         makeOffer: service.walletConnection.makeOffer,
       },
-      callback: async () => {
-        console.info("MintCharacter call settled");
-      },
-      errorCallback: body.setError,
+      callback: body.callback,
     });
   });
 };

--- a/frontend/src/service/character/inventory.ts
+++ b/frontend/src/service/character/inventory.ts
@@ -1,5 +1,5 @@
 import { makeCopyBag } from "@agoric/store";
-import { Character, Item } from "../../interfaces";
+import { Character, HandleOfferResultFunction, Item } from "../../interfaces";
 import { urlToCid } from "../../util/other";
 
 // TODO: Use makeOffer status callback for errors
@@ -13,7 +13,7 @@ interface UnequipItem {
     itemBrand: any;
     makeOffer: any;
   };
-  callback: () => Promise<void>;
+  callback: HandleOfferResultFunction
 }
 
 const unequipItem = async ({ item, character, service, callback }: UnequipItem): Promise<void> => {
@@ -56,18 +56,7 @@ const unequipItem = async ({ item, character, service, callback }: UnequipItem):
   };
 
 
-  service.makeOffer(spec, proposal, undefined, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, undefined, callback);
 };
 
 interface UnequipAllItems {
@@ -107,18 +96,7 @@ const unequipAll = async ({ character, service, callback }: UnequipAllItems): Pr
     give,
   };
 
-  service.makeOffer(spec, proposal, undefined, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, undefined, callback);
 };
 
 interface EquipItem {
@@ -130,7 +108,7 @@ interface EquipItem {
     itemBrand: any;
     makeOffer: any;
   };
-  callback: () => Promise<void>;
+  callback: HandleOfferResultFunction;
 }
 
 const equipItem = async ({ item, character, service, callback }: EquipItem): Promise<void> => {
@@ -145,7 +123,7 @@ const equipItem = async ({ item, character, service, callback }: EquipItem): Pro
     ...item,
     image: urlToCid(item.image),
     thumbnail: urlToCid(item.thumbnail),
-};
+  };
 
   const spec = {
     source: "contract",
@@ -170,18 +148,7 @@ const equipItem = async ({ item, character, service, callback }: EquipItem): Pro
     give,
   };
 
-  service.makeOffer(spec, proposal, undefined, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, undefined, callback);
 };
 
 interface SwapItems {
@@ -194,7 +161,7 @@ interface SwapItems {
     itemBrand: any;
     makeOffer: any;
   };
-  callback: () => Promise<void>;
+  callback: HandleOfferResultFunction
 }
 
 const swapItems = async ({ giveItem, wantItem, character, service, callback }: SwapItems): Promise<void> => {
@@ -209,12 +176,12 @@ const swapItems = async ({ giveItem, wantItem, character, service, callback }: S
     ...giveItem,
     image: urlToCid(giveItem.image),
     thumbnail: urlToCid(giveItem.thumbnail),
-};
+  };
   const itemWant: Item = {
     ...wantItem,
     image: urlToCid(wantItem.image),
     thumbnail: urlToCid(wantItem.thumbnail),
-};
+  };
 
 
   const spec = {
@@ -241,18 +208,7 @@ const swapItems = async ({ giveItem, wantItem, character, service, callback }: S
     give,
   };
 
-  service.makeOffer(spec, proposal, undefined, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, undefined, callback);
 };
 
 export const inventoryService = { unequipItem, equipItem, unequipAll, swapItems };

--- a/frontend/src/service/character/inventory.ts
+++ b/frontend/src/service/character/inventory.ts
@@ -1,5 +1,5 @@
 import { makeCopyBag } from "@agoric/store";
-import { Character, HandleOfferResultFunction, Item } from "../../interfaces";
+import { Character, HandleOfferResult, Item } from "../../interfaces";
 import { urlToCid } from "../../util/other";
 
 // TODO: Use makeOffer status callback for errors
@@ -13,7 +13,7 @@ interface UnequipItem {
     itemBrand: any;
     makeOffer: any;
   };
-  callback: HandleOfferResultFunction
+  callback: HandleOfferResult;
 }
 
 const unequipItem = async ({ item, character, service, callback }: UnequipItem): Promise<void> => {
@@ -54,7 +54,6 @@ const unequipItem = async ({ item, character, service, callback }: UnequipItem):
     want,
     give,
   };
-
 
   service.makeOffer(spec, proposal, undefined, callback);
 };
@@ -108,7 +107,7 @@ interface EquipItem {
     itemBrand: any;
     makeOffer: any;
   };
-  callback: HandleOfferResultFunction;
+  callback: HandleOfferResult;
 }
 
 const equipItem = async ({ item, character, service, callback }: EquipItem): Promise<void> => {
@@ -161,7 +160,7 @@ interface SwapItems {
     itemBrand: any;
     makeOffer: any;
   };
-  callback: HandleOfferResultFunction
+  callback: HandleOfferResult;
 }
 
 const swapItems = async ({ giveItem, wantItem, character, service, callback }: SwapItems): Promise<void> => {
@@ -182,7 +181,6 @@ const swapItems = async ({ giveItem, wantItem, character, service, callback }: S
     image: urlToCid(wantItem.image),
     thumbnail: urlToCid(wantItem.thumbnail),
   };
-
 
   const spec = {
     source: "contract",

--- a/frontend/src/service/character/market.ts
+++ b/frontend/src/service/character/market.ts
@@ -1,5 +1,5 @@
 import { makeCopyBag } from "@agoric/store";
-import { Character, Item } from "../../interfaces";
+import { Character, HandleOfferResult, Item } from "../../interfaces";
 import { urlToCid } from "../../util/other";
 // TODO: Use makeOffer status callback for errors
 
@@ -12,7 +12,7 @@ interface CharacterMarketAction {
     istBrand: any;
     makeOffer: any;
   };
-  callback: () => Promise<void>;
+  callback: HandleOfferResult;
 }
 
 const sellCharacter = async ({ character, price, service, callback }: CharacterMarketAction): Promise<void> => {
@@ -40,19 +40,7 @@ const sellCharacter = async ({ character, price, service, callback }: CharacterM
     give,
   };
 
-  service.makeOffer(spec, proposal, undefined, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-      callback();
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, undefined, callback);
 };
 
 const buyCharacter = async ({ character, price, service, callback }: CharacterMarketAction): Promise<void> => {
@@ -81,19 +69,7 @@ const buyCharacter = async ({ character, price, service, callback }: CharacterMa
     give,
   };
 
-  service.makeOffer(spec, proposal, undefined, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-      callback();
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, undefined, callback);
 };
 
 interface ItemMarketAction {
@@ -106,7 +82,7 @@ interface ItemMarketAction {
     istBrand: any;
     makeOffer: any;
   };
-  callback: () => Promise<void>;
+  callback: HandleOfferResult;
 }
 
 const sellItem = async ({ item, price, service, callback }: ItemMarketAction): Promise<void> => {
@@ -139,19 +115,7 @@ const sellItem = async ({ item, price, service, callback }: ItemMarketAction): P
     give,
   };
 
-  service.makeOffer(spec, proposal, undefined, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-      callback();
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, undefined, callback);
 };
 
 interface SellItemBatchAction {
@@ -236,19 +200,7 @@ const buyItem = async ({ entryId, item, price, service, callback }: ItemMarketAc
     give,
   };
 
-  service.makeOffer(spec, proposal, { entryId: Number(entryId) }, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-      callback();
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, { entryId: Number(entryId) }, callback);
 };
 
 export const marketService = { sellCharacter, buyCharacter, sellItem, sellItemBatch, buyItem };

--- a/frontend/src/service/character/mint.ts
+++ b/frontend/src/service/character/mint.ts
@@ -1,5 +1,5 @@
 import { MINTING_COST } from "../../constants";
-import { HandleOfferResultBuilderFunction } from "../../interfaces";
+import { HandleOfferResultFunction } from "../../interfaces";
 
 // TODO: Use makeOffer status callback for errors
 
@@ -10,7 +10,7 @@ interface MintCharacter {
     istBrand: any;
     makeOffer: any;
   };
-  callback: ReturnType<HandleOfferResultBuilderFunction>;
+  callback: HandleOfferResultFunction;
 }
 
 export const mintCharacter = async ({ name, service, callback }: MintCharacter): Promise<void> => {

--- a/frontend/src/service/character/mint.ts
+++ b/frontend/src/service/character/mint.ts
@@ -30,6 +30,5 @@ export const mintCharacter = async ({ name, service, callback }: MintCharacter):
   const proposal = {
     give,
   };
-  console.log(callback)
   service.makeOffer(spec, proposal, offerArgs, callback);
 };

--- a/frontend/src/service/character/mint.ts
+++ b/frontend/src/service/character/mint.ts
@@ -1,5 +1,5 @@
 import { MINTING_COST } from "../../constants";
-import { HandleOfferResultFunction } from "../../interfaces";
+import { HandleOfferResult } from "../../interfaces";
 
 // TODO: Use makeOffer status callback for errors
 
@@ -10,7 +10,7 @@ interface MintCharacter {
     istBrand: any;
     makeOffer: any;
   };
-  callback: HandleOfferResultFunction;
+  callback: HandleOfferResult;
 }
 
 export const mintCharacter = async ({ name, service, callback }: MintCharacter): Promise<void> => {
@@ -30,6 +30,6 @@ export const mintCharacter = async ({ name, service, callback }: MintCharacter):
   const proposal = {
     give,
   };
-
+  console.log(callback)
   service.makeOffer(spec, proposal, offerArgs, callback);
 };

--- a/frontend/src/service/character/mint.ts
+++ b/frontend/src/service/character/mint.ts
@@ -1,4 +1,5 @@
 import { MINTING_COST } from "../../constants";
+import { HandleOfferResultBuilderFunction } from "../../interfaces";
 
 // TODO: Use makeOffer status callback for errors
 
@@ -9,11 +10,10 @@ interface MintCharacter {
     istBrand: any;
     makeOffer: any;
   };
-  callback: () => Promise<void>;
-  errorCallback?: (error: string) => void;
+  callback: ReturnType<HandleOfferResultBuilderFunction>;
 }
 
-export const mintCharacter = async ({ name, service, callback, errorCallback }: MintCharacter): Promise<void> => {
+export const mintCharacter = async ({ name, service, callback }: MintCharacter): Promise<void> => {
   const instance = service.kreadInstance;
   const spec = {
     source: "contract",
@@ -31,17 +31,5 @@ export const mintCharacter = async ({ name, service, callback, errorCallback }: 
     give,
   };
 
-  service.makeOffer(spec, proposal, offerArgs, ({ status, data }: { status: string; data: object }) => {
-    if (status === "error") {
-      console.error("Offer error", data);
-      if(errorCallback) errorCallback(JSON.stringify(data));
-    }
-    if (status === "refunded") {
-      console.error("Offer refunded", data);
-    }
-    if (status === "accepted") {
-      console.info("Offer accepted", data);
-      callback();
-    }
-  });
+  service.makeOffer(spec, proposal, offerArgs, callback);
 };

--- a/frontend/src/service/items.ts
+++ b/frontend/src/service/items.ts
@@ -153,13 +153,15 @@ export const useSellItem = (itemName: string | undefined, itemCategory: Category
         const itemBrand = service.tokenInfo.item.brand;
         const uISTPrice = ISTTouIST(price);
 
+        const originalSuccessCallbackFunction = callback.successCallbackFunction;
         callback.successCallbackFunction = () => {
-          if (callback.successCallbackFunction) callback.successCallbackFunction();
+          if (originalSuccessCallbackFunction) originalSuccessCallbackFunction();
           console.info("SellItem call settled");
           setIsLoading(false);
         };
+        const originalRefundCallbackFunction = callback.refundCallbackFunction;
         callback.refundCallbackFunction = () => {
-          if (callback.refundCallbackFunction) callback.refundCallbackFunction();
+          if (originalRefundCallbackFunction) originalRefundCallbackFunction();
           console.info("SellItem call settled");
           setIsLoading(false);
         };
@@ -208,14 +210,16 @@ export const useBuyItem = (itemToBuy: ItemInMarket | undefined) => {
         const { forSale, equippedTo, activity, ...itemObject } = itemToBuy.item;
         itemToBuy.item = itemObject;
 
+        const originalSuccessCallbackFunction = callback.successCallbackFunction;
         callback.successCallbackFunction = () => {
-          if (callback.successCallbackFunction) callback.successCallbackFunction();
+          if (originalSuccessCallbackFunction) originalSuccessCallbackFunction();
           console.info("BuyItem call settled");
           setIsLoading(false);
           setIsAwaitingApprovalToFalse();
         };
+        const originalRefundCallbackFunction = callback.refundCallbackFunction;
         callback.refundCallbackFunction = () => {
-          if (callback.refundCallbackFunction) callback.refundCallbackFunction();
+          if (originalRefundCallbackFunction) originalRefundCallbackFunction();
           console.info("BuyItem call settled");
           setIsLoading(false);
           setIsAwaitingApprovalToFalse();
@@ -269,9 +273,10 @@ export const useEquipItem = () => {
     if (body.currentlyEquipped) {
       const { forSale: f_, equippedTo: e_, activity: a_, ...itemToUnequip } = body.currentlyEquipped;
 
-      body.callback.errorCallbackFunction = (data) => {
+      const originalSuccessCallbackFunction = body.callback.successCallbackFunction;
+      body.callback.successCallbackFunction = () => {
         console.info("Swap call settled");
-        if (body.callback.errorCallbackFunction) body.callback.errorCallbackFunction(data);
+        if (originalSuccessCallbackFunction) originalSuccessCallbackFunction();
         setTimeout(() => userStateDispatch({ type: "END_INVENTORY_CALL" }), INVENTORY_CALL_FETCH_DELAY);
       };
       await inventoryService.swapItems({
@@ -287,9 +292,10 @@ export const useEquipItem = () => {
         callback: body.callback.getHandleOfferResult(),
       });
     } else {
-      body.callback.errorCallbackFunction = (data) => {
+      const originalSuccessCallbackFunction = body.callback.successCallbackFunction;
+      body.callback.successCallbackFunction = () => {
         console.info("Equip call settled");
-        if (body.callback.errorCallbackFunction) body.callback.errorCallbackFunction(data);
+        if (originalSuccessCallbackFunction) originalSuccessCallbackFunction();
         setTimeout(() => userStateDispatch({ type: "END_INVENTORY_CALL" }), INVENTORY_CALL_FETCH_DELAY);
       };
       await inventoryService.equipItem({
@@ -325,15 +331,13 @@ export const useUnequipItem = () => {
       console.error("Could find character to unequip from");
       return;
     }
-    console.log("BEFORE:", body.callback.errorCallbackFunction)
 
-    body.callback.errorCallbackFunction = (data) => {
+    const originalSuccessCallbackFunction = body.callback.successCallbackFunction
+    body.callback.successCallbackFunction = () => {
       console.info("Unequip call settled");
-      if (body.callback.errorCallbackFunction) body.callback.errorCallbackFunction(data);
+      if (originalSuccessCallbackFunction) originalSuccessCallbackFunction();
       setTimeout(() => userStateDispatch({ type: "END_INVENTORY_CALL" }), INVENTORY_CALL_FETCH_DELAY);
     };
-
-    // console.log("AFTER: ", body.callback.getHandleOfferResult())
 
     await inventoryService.unequipItem({
       item: itemToUnequip,

--- a/frontend/src/util/contract-callbacks.ts
+++ b/frontend/src/util/contract-callbacks.ts
@@ -1,20 +1,26 @@
-import { HandleOfferResultBuilderFunction } from "../interfaces";
+import { HandleOfferResult, HandleOfferResultBuilderFunction } from "../interfaces";
 
-export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (errorCallback?, refundCallback?, successCallback?) => {
-    return ({ status, data }: { status: string; data: object }) => {
-      if (status === "error") {
-        console.error("Offer error", data);
-        if (errorCallback) errorCallback(JSON.stringify(data));
-      }
-      if (status === "refunded") {
-        console.error("Offer refunded", data);
-        if (refundCallback) refundCallback();
-      }
-      if (status === "accepted") {
-        console.info("Offer accepted", data);
-        if (successCallback) successCallback();
-      }
-    };
+export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (errorCallback, refundCallback, successCallback) => { 
+  return {
+    errorCallbackFunction: errorCallback,
+    refundCallbackFunction: refundCallback,
+    successCallbackFunction: successCallback,
+    getHandleOfferResult() {
+      return (({ status, data }: { status: string; data: object }) => {
+        console.log("HERE WITH STATUS: ", status)
+        if (status === "error") {
+          console.error("Offer error", data);
+          if (this.errorCallbackFunction) this.errorCallbackFunction(JSON.stringify(data));
+        }
+        if (status === "refunded") {
+          console.error("Offer refunded", data);
+          if (this.refundCallbackFunction) this.refundCallbackFunction();
+        }
+        if (status === "accepted") {
+          console.info("Offer accepted", data);
+          if (this.successCallbackFunction) this.successCallbackFunction();
+        }
+      }).bind<HandleOfferResult>(this);
+    },
   };
-
-} 
+};

--- a/frontend/src/util/contract-callbacks.ts
+++ b/frontend/src/util/contract-callbacks.ts
@@ -20,6 +20,10 @@ export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (error
           console.info("Offer accepted", data);
           if (this.successCallbackFunction) this.successCallbackFunction();
         }
+        if (status === "seated") {
+          console.info("Offer accepted", data);
+          if (this.successCallbackFunction) this.successCallbackFunction();
+        }
       }).bind<HandleOfferResult>(this);
     },
   };

--- a/frontend/src/util/contract-callbacks.ts
+++ b/frontend/src/util/contract-callbacks.ts
@@ -23,11 +23,6 @@ export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (error
             if (this.successCallbackFunction) this.successCallbackFunction();
             break;
           }
-          case OFFER_STATUS.seated: {
-            console.info("Offer accepted", data);
-            if (this.successCallbackFunction) this.successCallbackFunction();
-            break;
-          }
         }
       }).bind<HandleOfferResult>(this);
     },

--- a/frontend/src/util/contract-callbacks.ts
+++ b/frontend/src/util/contract-callbacks.ts
@@ -1,4 +1,4 @@
-import { HandleOfferResult, HandleOfferResultBuilderFunction } from "../interfaces";
+import { HandleOfferResult, HandleOfferResultBuilderFunction, OFFER_STATUS, OfferStatusType } from "../interfaces";
 
 export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (errorCallback, refundCallback, successCallback) => { 
   return {
@@ -6,23 +6,28 @@ export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (error
     refundCallbackFunction: refundCallback,
     successCallbackFunction: successCallback,
     getHandleOfferResult() {
-      return (({ status, data }: { status: string; data: object }) => {
-        console.log("HERE WITH STATUS: ", status)
-        if (status === "error") {
-          console.error("Offer error", data);
-          if (this.errorCallbackFunction) this.errorCallbackFunction(JSON.stringify(data));
-        }
-        if (status === "refunded") {
-          console.error("Offer refunded", data);
-          if (this.refundCallbackFunction) this.refundCallbackFunction();
-        }
-        if (status === "accepted") {
-          console.info("Offer accepted", data);
-          if (this.successCallbackFunction) this.successCallbackFunction();
-        }
-        if (status === "seated") {
-          console.info("Offer accepted", data);
-          if (this.successCallbackFunction) this.successCallbackFunction();
+      return (({ status, data }: { status: OfferStatusType; data: object }) => {
+        switch (status) {
+          case OFFER_STATUS.error: {
+            console.error("Offer error", data);
+            if (this.errorCallbackFunction) this.errorCallbackFunction(JSON.stringify(data));
+            break;
+          }
+          case OFFER_STATUS.refunded: {
+            console.error("Offer refunded", data);
+            if (this.refundCallbackFunction) this.refundCallbackFunction();
+            break;
+          }
+          case OFFER_STATUS.accepted: {
+            console.info("Offer accepted", data);
+            if (this.successCallbackFunction) this.successCallbackFunction();
+            break;
+          }
+          case OFFER_STATUS.seated: {
+            console.info("Offer accepted", data);
+            if (this.successCallbackFunction) this.successCallbackFunction();
+            break;
+          }
         }
       }).bind<HandleOfferResult>(this);
     },

--- a/frontend/src/util/contract-callbacks.ts
+++ b/frontend/src/util/contract-callbacks.ts
@@ -1,0 +1,20 @@
+import { HandleOfferResultBuilderFunction } from "../interfaces";
+
+export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (errorCallback, refundCallback, successCallback) => {
+    return ({ status, data }: { status: string; data: object }) => {
+      if (status === "error") {
+        console.error("Offer error", data);
+        if (errorCallback) errorCallback(JSON.stringify(data));
+      }
+      if (status === "refunded") {
+        console.error("Offer refunded", data);
+        if (refundCallback) refundCallback();
+      }
+      if (status === "accepted") {
+        console.info("Offer accepted", data);
+        if (successCallback) successCallback();
+      }
+    };
+  };
+
+} 

--- a/frontend/src/util/contract-callbacks.ts
+++ b/frontend/src/util/contract-callbacks.ts
@@ -1,6 +1,6 @@
 import { HandleOfferResultBuilderFunction } from "../interfaces";
 
-export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (errorCallback, refundCallback, successCallback) => {
+export const handleOfferResultBuilder: HandleOfferResultBuilderFunction = (errorCallback?, refundCallback?, successCallback?) => {
     return ({ status, data }: { status: string; data: object }) => {
       if (status === "error") {
         console.error("Offer error", data);


### PR DESCRIPTION
## Description
In this PR:

Created a new pattern for creating offer callbacks that get passed the the wallet's `makeOffer` function. The pattern defined in `contract-callbacks.ts` allows developers to define their callback functions in the view components themselves. Also, having passed the callback from the view component to the hooks you are able to overwrite the callback and add common logic to them (see for example `sevice/character.ts` `useBuyCharacter` hook).
 